### PR TITLE
Add <idea-version/> in plugin.xml with min 203.5981.155

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,9 @@
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
 
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <idea-version since-build="203.5981.155"/>
+
     <extensions defaultExtensionNs="com.intellij">
         <!-- Annotators -->
         <annotator language="IJProlog"


### PR DESCRIPTION
I believe this tag is required for IDEA to allow installing this plugin on any version from specified min and onwards. Without it IDEA seems to restrict min and max to current minor version of the IDE used to build the jar.

Could not build to test sadly, got some complaints about PSI classes being missing.

Closes #63