### PR TITLE
adding ñ to fix issue #124

### DIFF
--- a/src/main/lang/prolog.bnf
+++ b/src/main/lang/prolog.bnf
@@ -38,8 +38,8 @@
       block_comment='regexp:/\*(.|\n)*\*/'
       integer='regexp:\d+'
       float='regexp:\d+(\.d+)?([Ee]\d+)?' // strict floating mode
-      const_id='regexp:\p{Lower}(\p{Alnum}|_|-|:)*'
-      atom_id='regexp:((\p{Upper}|_)(\p{Alnum}|_)*)'
+      const_id='regexp:\p{Lower}([\p{Alnum}ñ]|_|-|:)*'
+      atom_id='regexp:((\p{Upper}|_)([\p{Alnum}ñ]|_)*)'
       operator_id='regexp:[<=>:!+\\\-*/]+' // considering that operators in prolog can fly everywhere...
       string="regexp:('([^'\\]|\\.)*'|\"([^\"\\]|\\.)*\")"
     ]


### PR DESCRIPTION
As per prolog docs source code [may have non English characters](https://www.swi-prolog.org/pldoc/man?section=intsrcfile)
so let´s add them when requested. here's the first one: the character `ñ`